### PR TITLE
Needs GHC >= 7.4 due to usage of Data.Monoid.<>

### DIFF
--- a/matrix.cabal
+++ b/matrix.cabal
@@ -29,7 +29,7 @@ Source-repository head
   location: git://github.com/Daniel-Diaz/matrix.git
 
 Library
-  Build-depends: base == 4.*
+  Build-depends: base >= 4.5 && < 5
                , vector >= 0.10 && < 0.11
                , deepseq >= 1.3.0.0 && < 1.5
                , primitive >= 0.5


### PR DESCRIPTION
I've revised existing versions so a new release is not needed: http://hackage.haskell.org/package/matrix/revisions/