### PR TITLE
Typo fixed in 'zero'.

### DIFF
--- a/Data/Matrix.hs
+++ b/Data/Matrix.hs
@@ -203,7 +203,7 @@ instance Traversable Matrix where
 -- | /O(rows*cols)/. The zero matrix of the given size.
 --
 -- > zero n m =
--- >                 n
+-- >                 m
 -- >   1 ( 0 0 ... 0 0 )
 -- >   2 ( 0 0 ... 0 0 )
 -- >     (     ...     )


### PR DESCRIPTION
Fixed a typo in the comment of `zero'.