### PR TITLE
Implement a diagonal matrix generator function.

### DIFF
--- a/Data/Matrix.hs
+++ b/Data/Matrix.hs
@@ -15,6 +15,7 @@ module Data.Matrix (
     -- ** Special matrices
   , zero
   , identity
+  , diagonal
   , permMatrix
     -- * List conversions
   , fromList , fromLists
@@ -289,6 +290,23 @@ matrix n m f = M n m 0 0 m $ V.create $ do
 --
 identity :: Num a => Int -> Matrix a
 identity n = matrix n n $ \(i,j) -> if i == j then 1 else 0
+
+-- | Diagonal matrix from a non-empty list given the desired size.
+--   The list must have at least /order/ elements.
+--
+-- > diagonal n [1..] =
+-- >                   n
+-- >   1 ( 1 0 ... 0   0 )
+-- >   2 ( 0 2 ... 0   0 )
+-- >     (     ...       )
+-- >     ( 0 0 ... n-1 0 )
+-- >   n ( 0 0 ... 0   n )
+--
+diagonal :: Num a =>
+            Int  -- ^ Order
+         -> [a]  -- ^ List of elements
+         -> Matrix a
+diagonal n xs = matrix n n $ \(i,j) -> if i == j then xs !! (i - 1) else 0
 
 -- | Create a matrix from a non-empty list given the desired size.
 --   The list must have at least /rows*cols/ elements.

--- a/test/Examples.hs
+++ b/test/Examples.hs
@@ -51,6 +51,9 @@ main = sequence_
   , testEquality "identity"
       ( identity 3 , fromList 3 3 [1,0,0 , 0,1,0 , 0,0,1]
         )
+  , testEquality "diagonal"
+      ( diagonal 3 [1..] , fromList 3 3 [1,0,0 , 0,2,0 , 0,0,3]
+        )
   , testEquality "transpose"
       ( transpose $ fromList 3 3 [1..9]
       , fromList 3 3 [1,4,7 , 2,5,8 , 3,6,9]


### PR DESCRIPTION
This is a simple implementation of a diagonal matrix generator function. There are quite a few different possible syntaxes that could go with a diagonal generator function, some are more math-inclined and some are more implementation-inclined. This probably needs discussion or maybe it isn't worth implementing.

A **math** implementation would come from the math syntax of `diag{1, 2, 3}` in linear algebra, which means that the function would be `diagonal :: (Num a) => [a] -> Matrix a` where the dimensions are inferred.

An implementation that goes with infinite lists would allow specifying dimensions and maintains consistency with `fromList` by using a list, so `diagonal :: (Num a) => Int -> [a] -> Matrix a`. This is the version implemented in this pull request.

Unfortunately, using lists would mean that it is inconsistent with `getDiag :: Matrix a -> V.Vector a`, which returns a `Data.Vector` instead. This also makes it harder to write a QC test case for `getDiag (diagonal (length xs) xs) = xs`.

Possible use cases are a few numeric linear algebra algorithms, and having a shorthand would be convenient.