### PR TITLE
Boxdrawing

### DIFF
--- a/Data/Matrix.hs
+++ b/Data/Matrix.hs
@@ -129,14 +129,18 @@ sizeStr n m = show n ++ "x" ++ show m
 
 -- | Display a matrix as a 'String' using the 'Show' instance of its elements.
 prettyMatrix :: Show a => Matrix a -> String
-prettyMatrix m@(M _ _ _ _ _ v) = concat
-  [ "┌ ", unwords (replicate (ncols m) (fill mx "")), " ┐\n"
-  , unlines [ "│ " <> unwords (fmap (\j -> fill mx $ show $ m ! (i,j)) [1..ncols m]) <> " │" | i <- [1..nrows m] ]
-  , "└ ", unwords (replicate (ncols m) (fill mx "")), " ┘\n"
-  ]
+prettyMatrix m = concat
+   [ "┌ ", unwords (replicate (ncols m) blank), " ┐\n"
+   , unlines
+   [ "│ " ++ unwords (fmap (\j -> fill $ strings ! (i,j)) [1..ncols m]) ++ " │" | i <- [1..nrows m] ]
+   , "└ ", unwords (replicate (ncols m) blank), " ┘\n"
+   ]
  where
-  mx = V.maximum $ fmap (length . show) v
-  fill k str = replicate (k - length str) ' ' ++ str
+   strings@(M _ _ _ _ _ v)  = fmap show m
+   widest = V.maximum $ fmap length v
+   fill str = replicate (widest - length str) ' ' ++ str
+   blank = fill ""
+
 
 instance Show a => Show (Matrix a) where
  show = prettyMatrix

--- a/Data/Matrix.hs
+++ b/Data/Matrix.hs
@@ -133,7 +133,7 @@ prettyMatrix m = concat
    [ "┌ ", unwords (replicate (ncols m) blank), " ┐\n"
    , unlines
    [ "│ " ++ unwords (fmap (\j -> fill $ strings ! (i,j)) [1..ncols m]) ++ " │" | i <- [1..nrows m] ]
-   , "└ ", unwords (replicate (ncols m) blank), " ┘\n"
+   , "└ ", unwords (replicate (ncols m) blank), " ┘"
    ]
  where
    strings@(M _ _ _ _ _ v)  = fmap show m

--- a/Data/Matrix.hs
+++ b/Data/Matrix.hs
@@ -129,8 +129,11 @@ sizeStr n m = show n ++ "x" ++ show m
 
 -- | Display a matrix as a 'String' using the 'Show' instance of its elements.
 prettyMatrix :: Show a => Matrix a -> String
-prettyMatrix m@(M _ _ _ _ _ v) = unlines
- [ "( " <> unwords (fmap (\j -> fill mx $ show $ m ! (i,j)) [1..ncols m]) <> " )" | i <- [1..nrows m] ]
+prettyMatrix m@(M _ _ _ _ _ v) = concat
+  [ "┌ ", unwords (replicate (ncols m) (fill mx "")), " ┐\n"
+  , unlines [ "│ " <> unwords (fmap (\j -> fill mx $ show $ m ! (i,j)) [1..ncols m]) <> " │" | i <- [1..nrows m] ]
+  , "└ ", unwords (replicate (ncols m) (fill mx "")), " ┘\n"
+  ]
  where
   mx = V.maximum $ fmap (length . show) v
   fill k str = replicate (k - length str) ' ' ++ str

--- a/matrix.cabal
+++ b/matrix.cabal
@@ -1,5 +1,5 @@
 Name: matrix
-Version: 0.3.5.0
+Version: 0.3.5.1
 Author: Daniel Díaz
 Category: Math
 Build-type: Simple


### PR DESCRIPTION
I had some fun and redid the `prettyMatrix` function to use the Unicode [box drawing](https://en.wikipedia.org/wiki/Box-drawing_character) characters to put square brackets around matrices when Shown.

```
λ> let a = fromLists [[1,2,3],[4,5,6],[7,8,9]]
λ> print a
```
emits
```
┌       ┐
│ 1 2 3 │
│ 4 5 6 │
│ 7 8 9 │
└       ┘
```
which, in my terminal, renders with smooth lines.

As ever with Show instances there's (still) a ridiculous amount of String concatenation; I removed one call to `show`; if you like I could have a go cleaning it up further I can.

Anyway, just thought it would be fun to replace the `( ... ) ` with ASCII art closer to what we'd write in mathematical notation.

AfC