### PR TITLE
Guard call to inverse

### DIFF
--- a/Data/Matrix.hs
+++ b/Data/Matrix.hs
@@ -543,12 +543,14 @@ transpose m = matrix (ncols m) (nrows m) $ \(i,j) -> m ! (j,i)
 
 -- | /O(rows*rows*rows) = O(cols*cols*cols)/. The inverse of a square matrix.
 --   Uses naive Gaussian elimination formula.
-inverse :: (Fractional a, Eq a) => Matrix a -> Either String (Matrix a)
+inverse :: (Fractional a, Ord a) => Matrix a -> Either String (Matrix a)
 inverse m
     | ncols m /= nrows m
         = Left
             $ "Inverting non-square matrix with dimensions "
                 ++ show (sizeStr (ncols m) (nrows m))
+    | detLU m == 0
+        = Left "Non-invertable matrix"
     | otherwise =
         let
             adjoinedWId = m <|> identity (nrows m)


### PR DESCRIPTION
Use `detLU` to check that the input matrix is not singular before attempting to calculate the inverse.

Would close #38, though in a clumsy fashion.

Right now the `inverse` function (or rather, internal `rref`) has a ton of error checking. I feel like there should be two paths to calculate the inverse; a safe, guarded one that accepts it might be more expensive to run (in which case might as well use the Caley-Hamilton method) and an unsafe, express, assume-you-know-what-you're-doing, maybe

``` haskell
unsafeInverse :: Matrix a -> Matrix a
```

anyway, patch attached

AfC
