### PR TITLE
Matrix Inversion Should be fixed for nearly singular matricies

### DIFF
--- a/Data/Matrix.hs
+++ b/Data/Matrix.hs
@@ -569,7 +569,7 @@ rref m
                 "Invalid dimensions "
                     ++ show (sizeStr (ncols m) (nrows m))
                     ++ "; the number of columns must be greater than or equal to the number of rows"
-        | otherwise             = rrefRefd (ref m)
+        | otherwise             = rrefRefd =<< (ref m)
     where
     rrefRefd mtx
         | nrows mtx == 1    = Right mtx
@@ -585,26 +585,28 @@ rref m
             in top' >>= return . (<-> bot)
 
 
-ref :: (Fractional a, Eq a) => Matrix a -> Matrix a
+ref :: (Fractional a, Eq a) => Matrix a -> Either String (Matrix a)
 ref mtx
         | nrows mtx == 1
             = clearedLeft
-        | otherwise =
-            let
-                (tl, tr, bl, br) = splitBlocks 1 1 clearedLeft
-                br' = ref br
-            in (tl <|> tr) <-> (bl <|> br')
+        | otherwise = do 
+                (tl, tr, bl, br) <- (splitBlocks 1 1 <$> clearedLeft)
+                br' <- ref br
+                return  ((tl <|> tr) <-> (bl <|> br'))
     where
-    sigAtTop = switchRows 1 goodRow mtx
+    sigAtTop = (\row -> switchRows 1 row mtx) <$> goodRow
         where
         significantRow n = getElem n 1 mtx /= 0
-        goodRow = case listToMaybe (filter significantRow [1..ncols mtx]) of
-            Nothing -> error "Attempt to invert a non-invertible matrix"
-            Just x -> x
-    normalizedFirstRow = scaleRow (1 / getElem 1 1 sigAtTop) 1 sigAtTop
-    clearedLeft = foldr (.) id (map combinator [2..nrows mtx]) normalizedFirstRow
+        goodRow = case listToMaybe (filter significantRow [1..nrows mtx]) of
+            Nothing -> Left "Attempt to invert a non-invertible matrix"
+            Just x -> return x
+    normalizedFirstRow = (\sigAtTop' -> scaleRow (1 / getElem 1 1 sigAtTop') 1 sigAtTop') <$> sigAtTop
+    clearedLeft =  do 
+            comb <- mapM combinator [2..nrows mtx]
+            firstRow <- normalizedFirstRow
+            return $ (foldr (.) id comb) firstRow
         where
-        combinator n = combineRows n (-getElem n 1 normalizedFirstRow) 1
+        combinator n = (\normalizedFirstRow'  ->combineRows n (-getElem n 1 normalizedFirstRow') 1) <$> normalizedFirstRow
 
 -- | Extend a matrix to a given size adding a default element.
 --   If the matrix already has the required size, nothing happens.

--- a/test/Examples.hs
+++ b/test/Examples.hs
@@ -135,4 +135,5 @@ main = sequence_
       ( inverse $ fromList 3 3 [1,0,0, 0,0,1, 0,1,0]
       , Right $ fromList 3 3 [1,0,0, 0,0,1, 0,1,0] :: Either String (Matrix Rational))
   , testExample "inverse (6)" $ isLeft $ inverse $ fromList 2 2 [1,1,2,2]
+    , testEquality "inverse (7)" $ (inverse $fromList 3 3 [0,0,0,0,0,0,0,0,0::Double], Left "Attempt to invert a non-invertible matrix"t )
     ]


### PR DESCRIPTION
Still need tests, Waiting on test case from @LATBauerdick 
Copied from his issue:

```
Hi -- hope this is the right way to report bugs for the Data.Matrix package!

There are two issues showing up when matrix inversion runs into problems (e.g. for nearly singular matrices):

in function ref:

goodRow = case listToMaybe (filter significantRow [1..ncols mtx]) of
            Nothing -> error "Attempt to invert a non-invertible matrix"
            Just x -> x

ncol needs to be nrows, current code crashes with access error instead of returning error.

as ref is called from inverse (and rref), which promises to return Either String (Matrix a), calling error in case of non-invertible matrices is not a very nice thing to do. ref should be modified to also return Either String (Matrix a), so inverse can return Left "can't invert". It's important that user code can handle singular or numerically unstable matrices themselves.

Thanks for your consideration (and thanks for providing Data.Matrix, which is otherwise a joy to use).

Best regards, LatB
```