### PR TITLE
Added symmetric Read/Show class implementations for serialization and deserialization

### DIFF
--- a/Data/Matrix.hs
+++ b/Data/Matrix.hs
@@ -144,7 +144,13 @@ prettyMatrix m = concat
 
 
 instance Show a => Show (Matrix a) where
- show = prettyMatrix
+ show = show . toLists
+
+instance Read a => Read (Matrix a) where
+ readsPrec _ str = map toMatrix parsedLists
+   where
+     parsedLists = reads str
+     toMatrix (lists, str) = (fromLists lists, str)
 
 instance NFData a => NFData (Matrix a) where
  rnf = rnf . mvect


### PR DESCRIPTION
I ended up adding symmetric implementations for the `Read` and `Show` classes in the library so that I could easily serialize/deserialize Matrix objects. I figured that it could be useful to others in the future so I'm creating a PR for the changes that I made.

I left the `prettyMatrix` function as-is so that users still have the option of printing human-readable Matrices.