### PR TITLE
Adds Semigroup (Matrix a) instance, which makes compatible with GHC >= 8.4

### DIFF
--- a/Data/Matrix.hs
+++ b/Data/Matrix.hs
@@ -77,6 +77,7 @@ import Control.Loop (numLoop,numLoopFold)
 import Data.Foldable (Foldable, foldMap, foldl1)
 import Data.Maybe
 import Data.Monoid
+import qualified Data.Semigroup as S
 import Data.Traversable
 import Control.Applicative(Applicative, (<$>), (<*>), pure)
 import GHC.Generics (Generic)
@@ -170,6 +171,9 @@ instance Functor Matrix where
 -------------------------------------------------------
 -------------------------------------------------------
 ---- MONOID INSTANCE
+
+instance Monoid a => S.Semigroup (Matrix a) where
+  (<>) = mappend
 
 instance Monoid a => Monoid (Matrix a) where
   mempty = fromList 1 1 [mempty]

--- a/matrix.cabal
+++ b/matrix.cabal
@@ -33,6 +33,7 @@ Library
                , vector >= 0.10
                , deepseq >= 1.3.0.0 && < 1.5
                , primitive >= 0.5
+               , semigroups >= 0.9
                , loop >= 0.2
   Exposed-modules: Data.Matrix
   GHC-Options: -Wall -O2 -fstatic-argument-transformation


### PR DESCRIPTION
Since upcoming GHC-8.4.x, `Semigroup` become a part of `base` and a superclass of `Monoid`.

This pull request adds missing `Monoid a => Semigroup (Matrix a)` instance to make it compatible GHC >= 8.4.